### PR TITLE
v0.4.11

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
   timeout:
     required: true
     description: 'time to wait for a matching instance (seconds)'
-    default: '60'
+    default: '180'
   runners:
     required: true
     description: 'the amount of runners to start with matching labels'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-action",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "private": true,
   "description": "TypeScript template action",
   "main": "lib/main.js",


### PR DESCRIPTION
Increase Default TImeout to 3mins. This is to help with the case in which a workflow initializing runners takes an outgoing runner from another workflow. That condition results in the requesting workflow both starting a runner and making a runner unable to be stopped by the other workflow.

My proposed fix is to set the default timeout to 3mins so an initializing runner can be turned on and then subsequently turned off by the other workflow.