### PR TITLE
Add a codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The following line will setup the Platform Engineering Team to be added to all Pull Requests for this repository.
+*   @hipcamp/platform-engineering

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  # Enable version updates for npm
-  - package-ecosystem: 'npm'
-    # Look for `package.json` and `lock` files in the `root` directory
-    directory: '/'
-    # Check the npm registry for updates every day (weekdays)
-    schedule:
-      interval: 'daily'


### PR DESCRIPTION
This PR is to add a codeowners file so that when Dependabot opens PRs, they'll be brought to our attention.